### PR TITLE
Remove old repo opx-mlnx-sdi-sys

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -31,7 +31,7 @@
   <project name="opx-nas-linux"/>
 
   <!-- SAI -->
-  <project path="opx-sai-api" name="SAI" revision="dell.1.2+"/>
+  <project name="opx-sai-api" revision="dell.1.2+"/>
   <project name="opx-sai-vm"/>
 
   <!-- The following section is for platform service configuration -->

--- a/default.xml
+++ b/default.xml
@@ -40,9 +40,6 @@
   <!-- SDI -->
   <project name="opx-sdi-sys"/>
 
-  <!-- SDI implementation for Mellanox platforms -->
-  <project name="opx-mlnx-sdi-sys"/>
-
   <!-- The following section is for the remaining miscellaneous packages -->
   <project name="opx-tmpctl"/>
 


### PR DESCRIPTION
opx-mlnx-sdi-sys does not currently build for Stretch.

Signed-off-by: Tyler Heucke <tyler.heucke@dell.com>