### PR TITLE
Remove old repo opx-mlnx-sdi-sys

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -40,9 +40,6 @@
   <!-- SDI -->
   <project name="opx-sdi-sys"/>
 
-  <!-- SDI implementation for Mellanox platforms -->
-  <project name="opx-mlnx-sdi-sys"/>
-
   <!-- The following section is for the remaining miscellaneous packages -->
   <project name="opx-tmpctl"/>
 


### PR DESCRIPTION
opx-mlnx-sdi-sys does not currently build for Stretch.

Signed-off-by: Tyler Heucke <tyler.heucke@dell.com>